### PR TITLE
Update the source allies logo image to a full URL

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,3 +1,3 @@
 # Welcome
 
-[![Source Allies](sa-logo.svg)](https://sourceallies.com/)
+[![Source Allies](https://raw.githubusercontent.com/sourceallies/.github/main/profile/sa-logo.svg)](https://sourceallies.com/)


### PR DESCRIPTION
I believe this is needed so that the logo properly shows up on the Organization profile as right now, it's trying to resolve a relative file path, which doesn't exist on github's server.